### PR TITLE
Only help if -h or --help is first arg

### DIFF
--- a/ddo
+++ b/ddo
@@ -26,11 +26,10 @@ function printv {
 verbose=$DDO_VERBOSE
 
 # aggregate all arguments until '--' as the command
+if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+die_usage
+fi
 while [[ $# -gt 0 ]] && [[ "$1" != '--' ]]; do
-    if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
-        die_usage
-    fi
-
     cmd="$cmd $1"
     shift 1
 done


### PR DESCRIPTION
Not sure how you feel about this one, but currently you can't call -h or --help on a function in docker with `ddo`.

> $ ddo python -h
> Usage: /usr/local/bin/ddo [-h | --help | COMMAND] [-- OPTIONS FOR DOCKER RUN]
> 
> Environment variables:
>     DDO_VERBOSE=1            to increase verbosity
>     DDO_RUN_WITH_MY_UID=1    to invoke 'docker run' with '-u CURRENT_UID'

Generally (I'd imagine) if you actually want `ddo` help I would assume you would pass the only the help flag. Let me know what you think.

After patch:

> $ ddo -h 
> 
> Usage: /usr/local/bin/ddo [-h | --help | COMMAND] [-- OPTIONS FOR DOCKER RUN]
> 
> Environment variables:
>    DDO_VERBOSE=1            to increase verbosity
>    DDO_RUN_WITH_MY_UID=1    to invoke 'docker run' with '-u CURRENT_UID'
> 
> $ ddo python -h
> usage: python [option] ... [-c cmd | -m mod | file | -] [arg] ...
> Options and arguments (and corresponding environment variables):
> ...
